### PR TITLE
Fix typo in Compounding enum variant

### DIFF
--- a/ak-core/src/compounding.rs
+++ b/ak-core/src/compounding.rs
@@ -5,5 +5,6 @@ pub enum Compounding {
     Simple,
     Compounded(Frequency),
     Continuous,
-    SimplteThenCompounded(Frequency),
+    /// Apply simple interest until a switch date and compound afterwards.
+    SimpleThenCompounded(Frequency),
 }


### PR DESCRIPTION
## Summary
- correct typo `SimplteThenCompounded` → `SimpleThenCompounded`
- add short comment describing the variant

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_684c74ef0a5083228f33fd11abd31959