### PR TITLE
Add tests for missing day count conventions

### DIFF
--- a/ak-core/src/day_count/nl_365.rs
+++ b/ak-core/src/day_count/nl_365.rs
@@ -23,3 +23,66 @@ impl DayCount for NL365 {
         self.day_diff(start, end) as f64 / 365.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jiff::civil::date;
+
+    #[test]
+    fn test_year_diff() {
+        let dc = NL365;
+        let start = date(2020, 1, 1);
+        let end = date(2021, 1, 1);
+        assert_eq!(dc.year_diff(start, end), 1.0);
+    }
+
+    #[test]
+    fn test_day_diff() {
+        let dc = NL365;
+        let start = date(2020, 1, 1);
+        let end = date(2020, 1, 31);
+        assert_eq!(dc.day_diff(start, end), 30);
+    }
+
+    #[test]
+    fn test_day_diffs() {
+        let cases = vec![
+            (date(1992, 2, 1), date(1992, 3, 1), 34),
+            (date(1993, 1, 1), date(1993, 2, 21), 51),
+            (date(1993, 1, 15), date(1993, 2, 1), 17),
+            (date(1993, 2, 1), date(1993, 3, 1), 34),
+            (date(1993, 2, 15), date(1993, 4, 1), 51),
+            (date(1993, 3, 15), date(1993, 6, 15), 94),
+            (date(1993, 3, 31), date(1993, 4, 1), 1),
+            (date(1993, 3, 31), date(1993, 4, 30), 30),
+            (date(1993, 7, 15), date(1993, 9, 15), 62),
+            (date(1993, 12, 15), date(1993, 12, 30), 15),
+        ];
+        for (start, end, expected) in cases {
+            assert_eq!(NL365.day_diff(start, end), expected);
+        }
+    }
+
+    #[test]
+    fn test_year_diffs() {
+        let cases = vec![
+            (date(1992, 2, 1), date(1992, 3, 1), 34),
+            (date(1993, 1, 1), date(1993, 2, 21), 51),
+            (date(1993, 1, 15), date(1993, 2, 1), 17),
+            (date(1993, 2, 1), date(1993, 3, 1), 34),
+            (date(1993, 2, 15), date(1993, 4, 1), 51),
+            (date(1993, 3, 15), date(1993, 6, 15), 94),
+            (date(1993, 3, 31), date(1993, 4, 1), 1),
+            (date(1993, 3, 31), date(1993, 4, 30), 30),
+            (date(1993, 7, 15), date(1993, 9, 15), 62),
+            (date(1993, 12, 15), date(1993, 12, 30), 15),
+        ];
+        for (start, end, expected_days) in cases {
+            let expected = expected_days as f64 / 365.0;
+            let result = NL365.year_diff(start, end);
+            assert!((result - expected).abs() < 1e-10, "{} {}", result, expected);
+        }
+    }
+}
+

--- a/ak-core/src/day_count/sia_30_360_eom.rs
+++ b/ak-core/src/day_count/sia_30_360_eom.rs
@@ -32,3 +32,55 @@ impl DayCount for SIA30360EOM {
         self.day_diff(start, end) as f64 / 360.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jiff::civil::date;
+
+    #[test]
+    fn test_year_diff() {
+        let dc = SIA30360EOM;
+        let start = date(2020, 1, 31);
+        let end = date(2021, 1, 31);
+        assert_eq!(dc.year_diff(start, end), 1.0);
+    }
+
+    #[test]
+    fn test_day_diff() {
+        let dc = SIA30360EOM;
+        let start = date(2020, 1, 31);
+        let end = date(2021, 1, 31);
+        assert_eq!(dc.day_diff(start, end), 360);
+    }
+
+    #[test]
+    fn test_day_diffs() {
+        let cases = vec![
+            (date(1992, 2, 1), date(1992, 3, 1), 30),
+            (date(1993, 1, 1), date(1993, 2, 21), 50),
+            (date(1993, 1, 1), date(1994, 1, 1), 360),
+            (date(1993, 1, 15), date(1993, 2, 1), 16),
+            (date(1993, 2, 1), date(1993, 3, 1), 30),
+            (date(1993, 2, 15), date(1993, 4, 1), 46),
+            (date(1993, 3, 15), date(1993, 6, 15), 90),
+            (date(1993, 3, 31), date(1993, 4, 1), 1),
+            (date(1993, 3, 31), date(1993, 4, 30), 30),
+            (date(1993, 3, 31), date(1993, 12, 31), 270),
+            (date(1993, 7, 15), date(1993, 9, 15), 60),
+            (date(1993, 8, 21), date(1994, 4, 11), 230),
+            (date(1993, 11, 1), date(1994, 3, 1), 120),
+            (date(1993, 12, 15), date(1993, 12, 30), 15),
+            (date(1993, 12, 15), date(1993, 12, 31), 16),
+            (date(1993, 12, 31), date(1994, 2, 1), 31),
+            (date(1996, 1, 15), date(1996, 5, 31), 136),
+            (date(1998, 2, 27), date(1998, 3, 27), 30),
+            (date(1998, 2, 28), date(1998, 3, 27), 27),
+            (date(1999, 1, 1), date(1999, 1, 29), 28),
+        ];
+        for (start, end, expected) in cases {
+            assert_eq!(SIA30360EOM.day_diff(start, end), expected);
+        }
+    }
+}
+

--- a/ak-core/src/day_count/sia_30_360_neom.rs
+++ b/ak-core/src/day_count/sia_30_360_neom.rs
@@ -21,3 +21,55 @@ impl DayCount for SIA30360NEOM {
         self.day_diff(start, end) as f64 / 360.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jiff::civil::date;
+
+    #[test]
+    fn test_year_diff() {
+        let dc = SIA30360NEOM;
+        let start = date(2020, 1, 31);
+        let end = date(2021, 1, 31);
+        assert_eq!(dc.year_diff(start, end), 1.0);
+    }
+
+    #[test]
+    fn test_day_diff() {
+        let dc = SIA30360NEOM;
+        let start = date(2020, 1, 31);
+        let end = date(2021, 1, 31);
+        assert_eq!(dc.day_diff(start, end), 360);
+    }
+
+    #[test]
+    fn test_day_diffs() {
+        let cases = vec![
+            (date(1992, 2, 1), date(1992, 3, 1), 30),
+            (date(1993, 1, 1), date(1993, 2, 21), 50),
+            (date(1993, 1, 1), date(1994, 1, 1), 360),
+            (date(1993, 1, 15), date(1993, 2, 1), 16),
+            (date(1993, 2, 1), date(1993, 3, 1), 30),
+            (date(1993, 2, 15), date(1993, 4, 1), 46),
+            (date(1993, 3, 15), date(1993, 6, 15), 90),
+            (date(1993, 3, 31), date(1993, 4, 1), 1),
+            (date(1993, 3, 31), date(1993, 4, 30), 30),
+            (date(1993, 3, 31), date(1993, 12, 31), 270),
+            (date(1993, 7, 15), date(1993, 9, 15), 60),
+            (date(1993, 8, 21), date(1994, 4, 11), 230),
+            (date(1993, 11, 1), date(1994, 3, 1), 120),
+            (date(1993, 12, 15), date(1993, 12, 30), 15),
+            (date(1993, 12, 15), date(1993, 12, 31), 15),
+            (date(1993, 12, 31), date(1994, 2, 1), 31),
+            (date(1996, 1, 15), date(1996, 5, 31), 135),
+            (date(1998, 2, 27), date(1998, 3, 27), 30),
+            (date(1998, 2, 28), date(1998, 3, 27), 29),
+            (date(1999, 1, 1), date(1999, 1, 29), 28),
+        ];
+        for (start, end, expected) in cases {
+            assert_eq!(SIA30360NEOM.day_diff(start, end), expected);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add test suites for `NL365`, `SIA30360EOM` and `SIA30360NEOM`
- use example dates to verify day and year differences

## Testing
- `cargo test -p ak-core --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684c7db7b250832297f1e8c8ebe5abee