### PR TITLE
Add debug visitor tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ name = "ak-contract"
 version = "0.1.0"
 dependencies = [
  "jiff",
+ "libc",
 ]
 
 [[package]]
@@ -74,6 +75,12 @@ checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
 ]
+
+[[package]]
+name = "libc"
+version = "0.2.173"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
 
 [[package]]
 name = "log"

--- a/ak-contract/Cargo.toml
+++ b/ak-contract/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2024"
 
 [dependencies]
 jiff = { workspace = true }
+
+[dev-dependencies]
+libc = "0.2"

--- a/ak-contract/src/observable/constant.rs
+++ b/ak-contract/src/observable/constant.rs
@@ -1,0 +1,2 @@
+#[derive(Clone, Debug)]
+pub struct Constant(pub f64);

--- a/ak-contract/src/observable/stock_price.rs
+++ b/ak-contract/src/observable/stock_price.rs
@@ -1,0 +1,2 @@
+#[derive(Clone, Debug)]
+pub struct StockPrice(pub f64);

--- a/ak-contract/src/visitor/debug.rs
+++ b/ak-contract/src/visitor/debug.rs
@@ -1,21 +1,32 @@
 use crate::{ast::Node, visitor::Visitor};
+use std::io::{self, Write};
 
-#[derive(Debug, Default)]
-pub struct DebugVisitor {
+#[derive(Debug)]
+pub struct DebugVisitor<W: Write> {
     depth: usize,
+    pub(crate) writer: W,
 }
 
-impl DebugVisitor {
+impl DebugVisitor<std::io::Stdout> {
     pub fn new() -> Self {
-        DebugVisitor { depth: 0 }
+        DebugVisitor {
+            depth: 0,
+            writer: io::stdout(),
+        }
     }
 }
 
-impl Visitor for DebugVisitor {
+impl<W: Write> DebugVisitor<W> {
+    pub fn with_writer(writer: W) -> Self {
+        DebugVisitor { depth: 0, writer }
+    }
+}
+
+impl<W: Write> Visitor for DebugVisitor<W> {
     fn pre_visit(&mut self, node: &Node) {
         // print this node at current depth
         let indent = "  ".repeat(self.depth);
-        println!("{}{:?}", indent, node);
+        writeln!(self.writer, "{}{:?}", indent, node).unwrap();
         // go deeper for children
         self.depth += 1;
     }
@@ -23,5 +34,67 @@ impl Visitor for DebugVisitor {
     fn post_visit(&mut self, _node: &Node) {
         // back out after all children
         self.depth -= 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{walk_node, Node};
+    use std::io::Cursor;
+
+    fn boxed(n: Node) -> Box<Node> {
+        Box::new(n)
+    }
+
+    fn capture_output(expr: &Node) -> String {
+        let cursor = Cursor::new(Vec::new());
+        let mut v = DebugVisitor::with_writer(cursor);
+        walk_node(&mut v, expr);
+        let cursor = v.writer;
+        String::from_utf8(cursor.into_inner()).unwrap()
+    }
+
+    #[test]
+    fn simple_add() {
+        let expr = boxed(Node::Add(
+            boxed(Node::Constant(1.0)),
+            boxed(Node::Constant(2.0)),
+        ));
+        let output = capture_output(&expr);
+        assert_eq!(
+            output,
+            "Add(Constant(1.0), Constant(2.0))\n  Constant(1.0)\n  Constant(2.0)\n"
+        );
+    }
+
+    #[test]
+    fn nested_add() {
+        let expr = boxed(Node::Add(
+            boxed(Node::Add(
+                boxed(Node::Constant(1.0)),
+                boxed(Node::Constant(2.0)),
+            )),
+            boxed(Node::Constant(3.0)),
+        ));
+        let output = capture_output(&expr);
+        assert_eq!(
+            output,
+            "Add(Add(Constant(1.0), Constant(2.0)), Constant(3.0))\n  Add(Constant(1.0), Constant(2.0))\n    Constant(1.0)\n    Constant(2.0)\n  Constant(3.0)\n"
+        );
+    }
+
+    #[test]
+    fn if_node() {
+        let expr = boxed(Node::If(
+            0,
+            boxed(Node::Constant(1.0)),
+            boxed(Node::Constant(2.0)),
+        ));
+        let output = capture_output(&expr);
+        assert_eq!(
+            output,
+            "If(0, Constant(1.0), Constant(2.0))\n  Constant(1.0)\n  Constant(2.0)\n"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- enable output injection for `DebugVisitor` and add `with_writer`
- test `DebugVisitor` with simple, nested, and conditional AST nodes
- add stub observable modules to satisfy compilation

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684e210b5624832297738e655dc094f5