### PR TITLE
Use rayon for parallel Monte Carlo paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,8 @@ dependencies = [
 name = "ak-sim"
 version = "0.1.0"
 dependencies = [
+ "ak-random",
+ "criterion",
  "rayon",
  "thiserror",
 ]

--- a/ak-random/src/lib.rs
+++ b/ak-random/src/lib.rs
@@ -1,2 +1,4 @@
+pub mod rng;
+pub use rng::RNG;
 pub mod gaussian;
 pub mod mrg32k3a;

--- a/ak-random/src/mrg32k3a.rs
+++ b/ak-random/src/mrg32k3a.rs
@@ -268,6 +268,31 @@ impl Mrg32k3a {
     }
 }
 
+use crate::rng::RNG;
+use rand_core::RngCore;
+
+impl RNG for Mrg32k3a {
+    fn init(&mut self, _dimensions: usize) {}
+
+    fn generate_gaussian(&mut self, output: &mut [f64]) {
+        for val in output {
+            let mut u = (self.core.next_u64() & 0xFFFF_FFFF) as f64 * Mrg32k3aCore::NORM;
+            if u >= 1.0 {
+                u = 1.0 - f64::EPSILON;
+            }
+            if u <= 0.0 {
+                u = f64::MIN_POSITIVE;
+            }
+            *val = crate::gaussian::approx_inverse_gaussian(u).unwrap();
+        }
+    }
+
+    fn set_stream(&mut self, stream: u64) {
+        self.core.core.set_stream(stream);
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -392,3 +417,4 @@ mod tests {
         }
     }
 }
+

--- a/ak-random/src/rng.rs
+++ b/ak-random/src/rng.rs
@@ -1,0 +1,5 @@
+pub trait RNG: Clone + Send {
+    fn init(&mut self, _dimensions: usize) {}
+    fn generate_gaussian(&mut self, output: &mut [f64]);
+    fn set_stream(&mut self, _stream: u64) {}
+}

--- a/ak-sim/Cargo.toml
+++ b/ak-sim/Cargo.toml
@@ -6,3 +6,11 @@ edition = "2024"
 [dependencies]
 rayon = { workspace = true }
 thiserror = { workspace = true }
+ak-random = { path = "../ak-random" }
+
+[dev-dependencies]
+criterion = "0.6"
+
+[[bench]]
+name = "monte_carlo_bench"
+harness = false

--- a/ak-sim/benches/monte_carlo_bench.rs
+++ b/ak-sim/benches/monte_carlo_bench.rs
@@ -1,0 +1,58 @@
+use ak_sim::{monte_carlo, Model, Product, Scenario};
+use ak_random::mrg32k3a::Mrg32k3a;
+use ak_random::RNG;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+#[derive(Clone)]
+struct DummyModel;
+
+impl Model for DummyModel {
+    fn simulation_dimensions(&self) -> usize { 1 }
+    fn init(&self, _: usize, _: usize) {}
+    fn generate_path(&self, g: &[f64], path: &mut Scenario) {
+        path.0[0].numeraire = g[0];
+    }
+}
+
+#[derive(Clone)]
+struct DummyProduct;
+
+impl Product for DummyProduct {
+    fn payoff_labels(&self) -> Vec<String> { vec!["dummy".into()] }
+    fn timeline(&self) -> usize { 1 }
+    fn defline(&self) -> usize { 1 }
+    fn payoffs(&self, path: &Scenario, result: &mut Vec<f64>) {
+        result[0] = path.samples()[0].numeraire;
+    }
+}
+
+fn sequential_simulate(prd: &DummyProduct, mdl: &DummyModel, rng: &Mrg32k3a, paths: usize) {
+    let payoff_count = prd.payoff_labels().len();
+    let mut result = vec![vec![0.0; payoff_count]; paths];
+    mdl.init(prd.timeline(), prd.defline());
+    let sim_dims = mdl.simulation_dimensions();
+    for i in 0..paths {
+        let mut r_local = rng.clone();
+        r_local.init(sim_dims);
+        r_local.set_stream(i as u64);
+        let mut g = vec![0.0; sim_dims];
+        r_local.generate_gaussian(&mut g);
+        let mut path = Scenario::new(prd.defline());
+        mdl.generate_path(&g, &mut path);
+        prd.payoffs(&path, &mut result[i]);
+    }
+    criterion::black_box(result);
+}
+
+fn bench_monte_carlo(c: &mut Criterion) {
+    let prd = DummyProduct;
+    let mdl = DummyModel;
+    let rng = Mrg32k3a::default();
+    let paths = 1024;
+
+    c.bench_function("sequential", |b| b.iter(|| sequential_simulate(&prd, &mdl, &rng, paths)));
+    c.bench_function("parallel", |b| b.iter(|| monte_carlo::simulate(&prd, &mdl, &rng, paths)));
+}
+
+criterion_group!(mc_benches, bench_monte_carlo);
+criterion_main!(mc_benches);

--- a/ak-sim/src/lib.rs
+++ b/ak-sim/src/lib.rs
@@ -35,10 +35,6 @@ pub trait Product {
     fn payoffs(&self, path: &Scenario, result: &mut Vec<f64>);
 }
 
-pub trait RNG: Clone {
-    fn init(&self, dimensions: usize);
-    fn generate_gaussian(&self, output: &mut [f64]);
-}
 
 pub trait Model: Clone {
     fn simulation_dimensions(&self) -> usize;

--- a/ak-sim/src/monte_carlo.rs
+++ b/ak-sim/src/monte_carlo.rs
@@ -1,25 +1,108 @@
-use crate::{Model, Product, RNG, Scenario};
+use crate::{Model, Product, Scenario};
+use ak_random::RNG;
+use rayon::prelude::*;
 
-pub fn simulate<P: Product, M: Model, R: RNG>(
+pub fn simulate<P, M, R>(
     prd: &P,
     mdl: &M,
     rng: &R,
     paths: usize,
-) -> Vec<Vec<f64>> {
-    let _mdl = mdl.clone();
-    let _rng = rng.clone();
-
+) -> Vec<Vec<f64>>
+where
+    P: Product + Sync,
+    M: Model + Sync,
+    R: RNG + Sync,
+{
     let payoffs = prd.payoff_labels().len();
     let mut results = vec![vec![0.0; payoffs]; paths];
-    _mdl.init(prd.timeline(), prd.defline());
-    _rng.init(_mdl.simulation_dimensions());
 
-    let mut gaussian_vec = vec![0.0; _mdl.simulation_dimensions()];
-    let mut path = Scenario::new(prd.defline());
-    results.iter_mut().for_each(|result| {
-        _rng.generate_gaussian(&mut gaussian_vec);
-        _mdl.generate_path(&gaussian_vec, &mut path);
-        prd.payoffs(&path, result);
-    });
+    mdl.init(prd.timeline(), prd.defline());
+
+    let sim_dims = mdl.simulation_dimensions();
+    let defline = prd.defline();
+
     results
+        .par_iter_mut()
+        .enumerate()
+        .for_each_init(
+            || {
+                let mut local_rng = rng.clone();
+                local_rng.init(sim_dims);
+                (
+                    local_rng,
+                    vec![0.0f64; sim_dims],
+                    Scenario::new(defline),
+                )
+            },
+            |state, (i, result)| {
+                let (rng, gaussian_vec, path) = state;
+                rng.set_stream(i as u64);
+                rng.generate_gaussian(gaussian_vec);
+                mdl.generate_path(gaussian_vec, path);
+                prd.payoffs(path, result);
+            },
+        );
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ak_random::{mrg32k3a::Mrg32k3a, RNG};
+
+    #[derive(Clone)]
+    struct DummyModel;
+
+    impl Model for DummyModel {
+        fn simulation_dimensions(&self) -> usize { 1 }
+        fn init(&self, _: usize, _: usize) {}
+        fn generate_path(&self, gaussian_vec: &[f64], path: &mut Scenario) {
+            path.0[0].numeraire = gaussian_vec[0];
+        }
+    }
+
+    #[derive(Clone)]
+    struct DummyProduct;
+
+    impl Product for DummyProduct {
+        fn payoff_labels(&self) -> Vec<String> { vec!["dummy".into()] }
+        fn timeline(&self) -> usize { 1 }
+        fn defline(&self) -> usize { 1 }
+        fn payoffs(&self, path: &Scenario, result: &mut Vec<f64>) {
+            result[0] = path.samples()[0].numeraire;
+        }
+    }
+
+    #[test]
+    fn parallel_matches_sequential() {
+        let prd = DummyProduct;
+        let mdl = DummyModel;
+        let rng = Mrg32k3a::default();
+        let paths = 16;
+
+        // Sequential reference using per-path streams
+        let mut expected = Vec::new();
+        let mut g = vec![0.0; mdl.simulation_dimensions()];
+        for i in 0..paths {
+            let mut r_local = rng.clone();
+            r_local.init(mdl.simulation_dimensions());
+            r_local.set_stream(i as u64);
+            let mut s = Scenario::new(prd.defline());
+            r_local.generate_gaussian(&mut g);
+            mdl.generate_path(&g, &mut s);
+            let mut res = vec![0.0];
+            prd.payoffs(&s, &mut res);
+            expected.push(res);
+        }
+
+        // Parallel simulation
+        let results = super::simulate(&prd, &mdl, &rng, paths);
+
+        for (r, e) in results.iter().zip(expected.iter()) {
+            for (a, b) in r.iter().zip(e.iter()) {
+                assert!(!a.is_nan() && !b.is_nan());
+                assert!((a - b).abs() < 1e-12);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- move Monte Carlo tests into `monte_carlo.rs`
- ensure `Mrg32k3a` implements the `RNG` trait before test module
- add a Criterion benchmark comparing sequential vs parallel simulation

## Testing
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_68546ff8996883229b492183f3d50553