### PR TITLE
Switch to faster Gaussian sampler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,7 @@ dependencies = [
  "criterion",
  "rand",
  "rand_core",
+ "rand_distr",
  "rayon",
  "thiserror",
 ]
@@ -342,6 +343,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
 
 [[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -477,6 +485,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]

--- a/ak-random/Cargo.toml
+++ b/ak-random/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 thiserror = { workspace = true }
 rand_core = { version = "0.9.3", features = ["std"] }
 rayon = { workspace = true }
+rand_distr = "0.5"
 
 [dev-dependencies]
 criterion = "0.6"

--- a/ak-random/src/mrg32k3a.rs
+++ b/ak-random/src/mrg32k3a.rs
@@ -2,6 +2,7 @@ use rand_core::{
     RngCore, SeedableRng,
     block::{BlockRng64, BlockRngCore},
 };
+use rand_distr::{Distribution, StandardNormal};
 use thiserror::Error;
 
 use crate::rng::RNG;
@@ -373,14 +374,8 @@ impl RNG for Mrg32k3a {
         } else {
             self.cached_gaussian.clear();
             for val in output {
-                let mut u = (self.core.next_u64() & 0xFFFF_FFFF) as f64 * Mrg32k3aCore::NORM;
-                if u >= 1.0 {
-                    u = 1.0 - f64::EPSILON;
-                }
-                if u <= 0.0 {
-                    u = f64::MIN_POSITIVE;
-                }
-                *val = crate::gaussian::approx_inverse_gaussian(u).unwrap();
+                let sample: f64 = StandardNormal.sample(self);
+                *val = sample;
                 self.cached_gaussian.push(*val);
             }
             self.antithetic = true;


### PR DESCRIPTION
## Summary
- add `rand_distr` dependency
- sample normals using the Ziggurat `StandardNormal` distribution instead of the inverse transform

## Testing
- `cargo check --workspace`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_685a16424b7883228ab846bf09b86b8b