### PR TITLE
Optimize RNG core math

### DIFF
--- a/ak-random/src/gaussian.rs
+++ b/ak-random/src/gaussian.rs
@@ -37,16 +37,24 @@ pub fn approx_inverse_gaussian(u: f64) -> Result<f64> {
     let y = u - 0.5;
     if y.abs() < 0.42 {
         let r = y * y;
-        Ok((A0 + y * (A1 + r * (A2 + r * A3)))
-            / (1.0 + r * (B0 + r * (B1 + r * (B2 + r * B3)))))
+        let num = A3.mul_add(r, A2).mul_add(r, A1).mul_add(y, A0);
+        let den = B3.mul_add(r, B2).mul_add(r, B1).mul_add(r, B0).mul_add(r, 1.0);
+        Ok(num / den)
     } else {
         let mut r = u;
         if y > 0.0 {
             r = 1.0 - u;
         }
         r = (-1.0 * r.ln()).ln();
-        let x = C0
-            + r * (C1 + r * (C2 + r * (C3 + r * (C4 + r * (C5 + r * (C6 + r * (C7 + r * C8)))))));
+        let x = C8
+            .mul_add(r, C7)
+            .mul_add(r, C6)
+            .mul_add(r, C5)
+            .mul_add(r, C4)
+            .mul_add(r, C3)
+            .mul_add(r, C2)
+            .mul_add(r, C1)
+            .mul_add(r, C0);
         Ok(if y < 0.0 { -x } else { x })
     }
 }

--- a/ak-random/src/mrg32k3a.rs
+++ b/ak-random/src/mrg32k3a.rs
@@ -74,18 +74,20 @@ impl Mrg32k3aCore {
         (z >> 1) ^ (z >> 32)
     }
 
+    #[inline(always)]
     fn mat_vec_mul(m: u64, a: &[[u64; 3]; 3], s: &mut [u64; 3]) {
         let mut res = [0u64; 3];
         for i in 0..3 {
             let mut total = 0u128;
-            (0..3).for_each(|j| {
-                total += (a[i][j] as u128 * s[j] as u128) % m as u128;
-            });
+            for j in 0..3 {
+                total += a[i][j] as u128 * s[j] as u128;
+            }
             res[i] = (total % m as u128) as u64;
         }
         s.copy_from_slice(&res);
     }
 
+    #[inline(always)]
     fn apply_matrix(&mut self, a1: &[[u64; 3]; 3], a2: &[[u64; 3]; 3]) {
         let mut v1 = [self.s10, self.s11, self.s12];
         let mut v2 = [self.s20, self.s21, self.s22];
@@ -142,7 +144,7 @@ impl Mrg32k3aCore {
         Ok(())
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn step_u64(&mut self) -> u64 {
         let mut r = self.s12.wrapping_sub(self.s22);
         r = r.wrapping_sub(Self::M1 * ((r.wrapping_sub(1)) >> 63));


### PR DESCRIPTION
## Summary
- inline the RNG matrix methods for LLVM unrolling
- reduce mod operations in matrix multiply
- use fused multiply-add for inverse Gaussian evaluation

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685a164b52548322b25c79145031bae5