### PR TITLE
Require cargo fmt/clippy before completion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,4 @@ This project is **TDD-first**. Correctness and performance are the core goals.
 - Add benchmarks for performance-sensitive changes.
 - Avoid premature micro-optimizations without evidence.
 - Keep APIs deterministic and well-specified.
+- ALWAYS run `cargo fmt` and `cargo clippy` and make sure tests pass prior to saying work is completed.


### PR DESCRIPTION
Add a completion checklist item to run cargo fmt, cargo clippy, and tests before marking work done.