### PR TITLE
Define Product, RNG, and Model modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@
 - **TDD-driven development**: tests guide design and ensure correctness.
 - **Benchmarking**: performance is continuously measured and validated.
 - **Low-level optimization**: careful memory layout, SIMD utilization, and parallelization are used where they matter most.
+
+## Core Modules
+
+- **product**: trait-based product definitions (states, cashflow kinds, required data layout).
+- **rng**: deterministic random and quasi-random streams with jump-ahead and block splitting.
+- **model**: trait-based projection engines that transform products into state-indexed cashflows.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod date;
 
+pub mod model;
 pub mod product;
 pub mod rng;
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -15,6 +15,103 @@ pub struct ModelConfig {
 ///
 /// Determinism: with identical inputs and an RNG stream in the same state,
 /// implementations must produce identical outputs in the provided buffers.
+///
+/// # Examples
+///
+/// ```rust
+/// use ak::model::{validate_buffers, Model, ModelConfig, ModelError};
+/// use ak::product::{
+///     Amount, CashflowBuffer, Product, ProductDefinition, ProductState, RequiredDataBuffer,
+///     RequiredDataLayout,
+/// };
+/// use ak::rng::RngCore;
+/// use ak::{Date, Frequency};
+///
+/// struct DemoProduct {
+///     definition: ProductDefinition,
+/// }
+///
+/// impl Product for DemoProduct {
+///     fn definition(&self) -> &ProductDefinition {
+///         &self.definition
+///     }
+///
+///     fn initial_state(&self) -> ProductState {
+///         ProductState::new(0, 1, Amount::zero())
+///     }
+///
+///     fn generate_required_data(
+///         &self,
+///         _time_index: usize,
+///         _state: &ProductState,
+///         _rng: &mut dyn RngCore,
+///         out: &mut RequiredDataBuffer,
+///     ) {
+///         out.set_policy_scalar(0, 1.0);
+///     }
+///
+///     fn cashflows(
+///         &self,
+///         _time_index: usize,
+///         _state: &ProductState,
+///         _data: &RequiredDataBuffer,
+///         out: &mut [Amount],
+///     ) {
+///         out[0] = Amount::zero();
+///     }
+///
+///     fn next_state(
+///         &self,
+///         _time_index: usize,
+///         state: &ProductState,
+///         _data: &RequiredDataBuffer,
+///         _rng: &mut dyn RngCore,
+///     ) -> ProductState {
+///         *state
+///     }
+/// }
+///
+/// struct DemoModel;
+///
+/// impl Model for DemoModel {
+///     fn run(
+///         &self,
+///         product: &dyn Product,
+///         config: &ModelConfig,
+///         rng: &mut dyn RngCore,
+///         cashflows: &mut CashflowBuffer,
+///         data: &mut RequiredDataBuffer,
+///     ) -> Result<(), ModelError> {
+///         validate_buffers(product.definition(), config.steps, cashflows, data)?;
+///         product.generate_required_data(0, &product.initial_state(), rng, data);
+///         Ok(())
+///     }
+/// }
+///
+/// struct ZeroRng;
+///
+/// impl RngCore for ZeroRng {
+///     fn next_u32(&mut self) -> u32 {
+///         0
+///     }
+/// }
+///
+/// let layout = RequiredDataLayout::new(1, 0).unwrap();
+/// let definition = ProductDefinition::new(1, 1, layout).unwrap();
+/// let product = DemoProduct { definition };
+/// let config = ModelConfig {
+///     start: Date::new(2024, 1, 1).unwrap(),
+///     frequency: Frequency::Monthly,
+///     steps: 1,
+/// };
+/// let times = vec![config.start];
+/// let mut cashflows = CashflowBuffer::new(1, 1, times).unwrap();
+/// let mut data = RequiredDataBuffer::new(layout, 1).unwrap();
+/// let mut rng = ZeroRng;
+/// DemoModel
+///     .run(&product, &config, &mut rng, &mut cashflows, &mut data)
+///     .unwrap();
+/// ```
 pub trait Model {
     fn run(
         &self,
@@ -47,7 +144,9 @@ pub fn validate_buffers(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::product::{Product, ProductState};
     use crate::product::{ProductDefinition, RequiredDataLayout};
+    use crate::rng::RngCore;
 
     #[test]
     fn validate_buffers_accepts_matching_layouts() {
@@ -73,5 +172,121 @@ mod tests {
         let cashflows = CashflowBuffer::new(2, 3, times).unwrap();
 
         assert!(validate_buffers(&definition, 1, &cashflows, &data).is_err());
+    }
+
+    struct TestProduct {
+        definition: ProductDefinition,
+    }
+
+    impl Product for TestProduct {
+        fn definition(&self) -> &ProductDefinition {
+            &self.definition
+        }
+
+        fn initial_state(&self) -> ProductState {
+            ProductState::new(0, 1, crate::product::Amount::zero())
+        }
+
+        fn generate_required_data(
+            &self,
+            _time_index: usize,
+            _state: &ProductState,
+            _rng: &mut dyn RngCore,
+            out: &mut RequiredDataBuffer,
+        ) {
+            out.set_policy_scalar(0, 3.5);
+            out.state_vector_mut(0)[0] = 1.25;
+        }
+
+        fn cashflows(
+            &self,
+            _time_index: usize,
+            _state: &ProductState,
+            _data: &RequiredDataBuffer,
+            out: &mut [crate::product::Amount],
+        ) {
+            out[0] = crate::product::Amount::zero();
+        }
+
+        fn next_state(
+            &self,
+            _time_index: usize,
+            state: &ProductState,
+            _data: &RequiredDataBuffer,
+            _rng: &mut dyn RngCore,
+        ) -> ProductState {
+            *state
+        }
+    }
+
+    struct TestModel;
+
+    impl Model for TestModel {
+        fn run(
+            &self,
+            product: &dyn Product,
+            config: &ModelConfig,
+            rng: &mut dyn RngCore,
+            cashflows: &mut CashflowBuffer,
+            data: &mut RequiredDataBuffer,
+        ) -> Result<(), ModelError> {
+            validate_buffers(product.definition(), config.steps, cashflows, data)?;
+            product.generate_required_data(0, &product.initial_state(), rng, data);
+            Ok(())
+        }
+    }
+
+    struct ZeroRng;
+
+    impl RngCore for ZeroRng {
+        fn next_u32(&mut self) -> u32 {
+            0
+        }
+    }
+
+    #[test]
+    fn model_run_rejects_required_data_layout_mismatch() {
+        let layout = RequiredDataLayout::new(1, 1).unwrap();
+        let definition = ProductDefinition::new(2, 1, layout).unwrap();
+        let product = TestProduct { definition };
+        let config = ModelConfig {
+            start: Date::new(2024, 1, 1).unwrap(),
+            frequency: Frequency::Monthly,
+            steps: 1,
+        };
+        let times = vec![config.start];
+        let mut cashflows = CashflowBuffer::new(2, 1, times).unwrap();
+        let wrong_layout = RequiredDataLayout::new(2, 1).unwrap();
+        let mut data = RequiredDataBuffer::new(wrong_layout, 2).unwrap();
+        let mut rng = ZeroRng;
+
+        assert!(
+            TestModel
+                .run(&product, &config, &mut rng, &mut cashflows, &mut data)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn model_run_populates_required_data_from_product() {
+        let layout = RequiredDataLayout::new(1, 1).unwrap();
+        let definition = ProductDefinition::new(1, 1, layout).unwrap();
+        let product = TestProduct { definition };
+        let config = ModelConfig {
+            start: Date::new(2024, 1, 1).unwrap(),
+            frequency: Frequency::Monthly,
+            steps: 1,
+        };
+        let times = vec![config.start];
+        let mut cashflows = CashflowBuffer::new(1, 1, times).unwrap();
+        let mut data = RequiredDataBuffer::new(layout, 1).unwrap();
+        let mut rng = ZeroRng;
+
+        TestModel
+            .run(&product, &config, &mut rng, &mut cashflows, &mut data)
+            .unwrap();
+
+        assert_eq!(data.policy_scalar(0), 3.5);
+        assert_eq!(data.state_vector(0)[0], 1.25);
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -12,6 +12,9 @@ pub struct ModelConfig {
 }
 
 /// Model interface to transform products into state-indexed cashflows.
+///
+/// Determinism: with identical inputs and an RNG stream in the same state,
+/// implementations must produce identical outputs in the provided buffers.
 pub trait Model {
     fn run(
         &self,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,0 +1,74 @@
+use crate::product::{CashflowBuffer, Product, ProductDefinition, RequiredDataBuffer};
+use crate::{Date, Frequency};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ModelError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ModelConfig {
+    pub start: Date,
+    pub frequency: Frequency,
+    pub steps: usize,
+}
+
+/// Model interface to transform products into state-indexed cashflows.
+pub trait Model {
+    fn run(
+        &self,
+        product: &dyn Product,
+        config: &ModelConfig,
+        rng: &mut dyn crate::rng::RngCore,
+        cashflows: &mut CashflowBuffer,
+        data: &mut RequiredDataBuffer,
+    ) -> Result<(), ModelError>;
+}
+
+pub fn validate_buffers(
+    definition: &ProductDefinition,
+    steps: usize,
+    cashflows: &CashflowBuffer,
+    data: &RequiredDataBuffer,
+) -> Result<(), ModelError> {
+    if cashflows.n_states() != definition.n_states
+        || cashflows.n_kinds() != definition.n_kinds
+        || cashflows.len_steps() != steps
+    {
+        return Err(ModelError);
+    }
+    if data.n_states() != definition.n_states || data.layout() != definition.required_data {
+        return Err(ModelError);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::product::{ProductDefinition, RequiredDataLayout};
+
+    #[test]
+    fn validate_buffers_accepts_matching_layouts() {
+        let layout = RequiredDataLayout::new(1, 2).unwrap();
+        let definition = ProductDefinition::new(2, 3, layout).unwrap();
+        let data = RequiredDataBuffer::new(layout, 2).unwrap();
+        let times = vec![
+            Date::new(2024, 1, 1).unwrap(),
+            Date::new(2024, 2, 1).unwrap(),
+        ];
+        let cashflows = CashflowBuffer::new(2, 3, times).unwrap();
+
+        assert!(validate_buffers(&definition, 2, &cashflows, &data).is_ok());
+    }
+
+    #[test]
+    fn validate_buffers_rejects_mismatched_data() {
+        let layout = RequiredDataLayout::new(1, 2).unwrap();
+        let definition = ProductDefinition::new(2, 3, layout).unwrap();
+        let wrong_layout = RequiredDataLayout::new(2, 2).unwrap();
+        let data = RequiredDataBuffer::new(wrong_layout, 2).unwrap();
+        let times = vec![Date::new(2024, 1, 1).unwrap()];
+        let cashflows = CashflowBuffer::new(2, 3, times).unwrap();
+
+        assert!(validate_buffers(&definition, 1, &cashflows, &data).is_err());
+    }
+}

--- a/src/product/cashflow.rs
+++ b/src/product/cashflow.rs
@@ -2,19 +2,23 @@ use std::ops::{Add, AddAssign, Neg, Sub, SubAssign};
 
 use crate::{Date, DateError, Frequency};
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Amount(i64);
+#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd)]
+pub struct Amount(f64);
 
 impl Amount {
     pub const fn zero() -> Self {
-        Self(0)
+        Self(0.0)
     }
 
-    pub const fn from_cents(cents: i64) -> Self {
-        Self(cents)
+    pub fn from_cents(cents: i64) -> Self {
+        Self((cents as f64) / 100.0)
     }
 
-    pub const fn cents(self) -> i64 {
+    pub const fn from_f64(value: f64) -> Self {
+        Self(value)
+    }
+
+    pub const fn value(self) -> f64 {
         self.0
     }
 }
@@ -55,25 +59,18 @@ impl Neg for Amount {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum CashflowKind {
-    Premium,
-    Benefit,
-    Expense,
-    Investment,
-    Tax,
-    Other,
-}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct CashflowKindId(pub usize);
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Cashflow {
     pub time: Date,
     pub amount: Amount,
-    pub kind: CashflowKind,
+    pub kind: CashflowKindId,
 }
 
 impl Cashflow {
-    pub fn new(time: Date, amount: Amount, kind: CashflowKind) -> Self {
+    pub fn new(time: Date, amount: Amount, kind: CashflowKindId) -> Self {
         Self { time, amount, kind }
     }
 
@@ -87,10 +84,101 @@ impl Cashflow {
         index: usize,
         frequency: Frequency,
         amount: Amount,
-        kind: CashflowKind,
+        kind: CashflowKindId,
     ) -> Result<Self, DateError> {
         let time = crate::cashflow_date_at(start, index, frequency)?;
         Ok(Self { time, amount, kind })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CashflowBufferError;
+
+/// SoA cashflow storage with fixed dimensions per state/kind/step.
+#[derive(Debug, Clone)]
+pub struct CashflowBuffer {
+    times: Vec<Date>,
+    amounts: Vec<Amount>,
+    n_states: usize,
+    n_kinds: usize,
+}
+
+impl CashflowBuffer {
+    pub fn new(
+        n_states: usize,
+        n_kinds: usize,
+        times: Vec<Date>,
+    ) -> Result<Self, CashflowBufferError> {
+        if n_states == 0 || n_kinds == 0 || times.is_empty() {
+            return Err(CashflowBufferError);
+        }
+        let len = n_states
+            .checked_mul(n_kinds)
+            .and_then(|v| v.checked_mul(times.len()))
+            .ok_or(CashflowBufferError)?;
+        Ok(Self {
+            times,
+            amounts: vec![Amount::zero(); len],
+            n_states,
+            n_kinds,
+        })
+    }
+
+    pub fn from_parts(
+        n_states: usize,
+        n_kinds: usize,
+        times: Vec<Date>,
+        amounts: Vec<Amount>,
+    ) -> Result<Self, CashflowBufferError> {
+        if n_states == 0 || n_kinds == 0 || times.is_empty() {
+            return Err(CashflowBufferError);
+        }
+        let expected = n_states
+            .checked_mul(n_kinds)
+            .and_then(|v| v.checked_mul(times.len()))
+            .ok_or(CashflowBufferError)?;
+        if expected != amounts.len() {
+            return Err(CashflowBufferError);
+        }
+        Ok(Self {
+            times,
+            amounts,
+            n_states,
+            n_kinds,
+        })
+    }
+
+    pub fn times(&self) -> &[Date] {
+        &self.times
+    }
+
+    pub fn n_states(&self) -> usize {
+        self.n_states
+    }
+
+    pub fn n_kinds(&self) -> usize {
+        self.n_kinds
+    }
+
+    pub fn len_steps(&self) -> usize {
+        self.times.len()
+    }
+
+    pub fn amount(&self, state: usize, kind: usize, step: usize) -> Amount {
+        let idx = self.offset(state, kind, step);
+        self.amounts[idx]
+    }
+
+    pub fn amount_mut(&mut self, state: usize, kind: usize, step: usize) -> &mut Amount {
+        let idx = self.offset(state, kind, step);
+        &mut self.amounts[idx]
+    }
+
+    fn offset(&self, state: usize, kind: usize, step: usize) -> usize {
+        debug_assert!(state < self.n_states);
+        debug_assert!(kind < self.n_kinds);
+        debug_assert!(step < self.times.len());
+        (state * self.n_kinds + kind) * self.times.len() + step
     }
 }
 
@@ -100,30 +188,30 @@ mod tests {
 
     #[test]
     fn amount_arithmetic_behaves_as_expected() {
-        let mut amount = Amount::from_cents(100);
-        amount += Amount::from_cents(50);
-        assert_eq!(amount, Amount::from_cents(150));
+        let mut amount = Amount::from_f64(100.0);
+        amount += Amount::from_f64(50.0);
+        assert_eq!(amount, Amount::from_f64(150.0));
 
-        amount -= Amount::from_cents(20);
-        assert_eq!(amount.cents(), 130);
+        amount -= Amount::from_f64(20.0);
+        assert_eq!(amount.value(), 130.0);
 
-        let total = amount + Amount::from_cents(70);
-        assert_eq!(total, Amount::from_cents(200));
+        let total = amount + Amount::from_f64(70.0);
+        assert_eq!(total, Amount::from_f64(200.0));
 
-        let diff = total - Amount::from_cents(25);
-        assert_eq!(diff, Amount::from_cents(175));
+        let diff = total - Amount::from_f64(25.0);
+        assert_eq!(diff, Amount::from_f64(175.0));
 
         let negated = -diff;
-        assert_eq!(negated, Amount::from_cents(-175));
+        assert_eq!(negated, Amount::from_f64(-175.0));
 
-        assert_eq!(Amount::zero(), Amount::from_cents(0));
+        assert_eq!(Amount::zero(), Amount::from_f64(0.0));
     }
 
     #[test]
     fn cashflow_construction_helpers_match_inputs() -> Result<(), DateError> {
         let date = Date::new(2024, 6, 15)?;
-        let amount = Amount::from_cents(12_345);
-        let kind = CashflowKind::Premium;
+        let amount = Amount::from_f64(12_345.0);
+        let kind = CashflowKindId(3);
 
         let flow = Cashflow::new(date, amount, kind);
         assert_eq!(flow.time, date);
@@ -134,6 +222,21 @@ mod tests {
         assert_eq!(from_period.amount, amount);
         assert_eq!(from_period.kind, kind);
         assert_eq!(from_period.time, Date::new(2024, 8, 15)?);
+        Ok(())
+    }
+
+    #[test]
+    fn cashflow_buffer_indexes_are_stable() -> Result<(), DateError> {
+        let times = vec![
+            Date::new(2024, 1, 1)?,
+            Date::new(2024, 2, 1)?,
+            Date::new(2024, 3, 1)?,
+        ];
+        let mut buffer = CashflowBuffer::new(2, 3, times).unwrap();
+        *buffer.amount_mut(1, 2, 0) = Amount::from_f64(42.0);
+        *buffer.amount_mut(0, 1, 2) = Amount::from_f64(-7.5);
+        assert_eq!(buffer.amount(1, 2, 0), Amount::from_f64(42.0));
+        assert_eq!(buffer.amount(0, 1, 2), Amount::from_f64(-7.5));
         Ok(())
     }
 }

--- a/src/product/definition.rs
+++ b/src/product/definition.rs
@@ -31,6 +31,9 @@ impl ProductDefinition {
 }
 
 /// Product interface describing cashflow kinds, states, and required data.
+///
+/// Determinism: given identical inputs and an RNG stream in the same state,
+/// implementations must produce identical outputs.
 pub trait Product {
     /// Returns the fixed definition of the product's dimensions.
     fn definition(&self) -> &ProductDefinition;
@@ -39,6 +42,8 @@ pub trait Product {
     fn initial_state(&self) -> ProductState;
 
     /// Generates required data into the provided buffer.
+    ///
+    /// Determinism: output must be fully determined by inputs and the RNG stream.
     fn generate_required_data(
         &self,
         time_index: usize,
@@ -50,6 +55,7 @@ pub trait Product {
     /// Writes cashflows for the current state into the provided buffer.
     ///
     /// The output slice length must match `definition().n_kinds`.
+    /// Determinism: output must be fully determined by inputs.
     fn cashflows(
         &self,
         time_index: usize,
@@ -59,6 +65,8 @@ pub trait Product {
     );
 
     /// Computes the next state after applying transitions.
+    ///
+    /// Determinism: output must be fully determined by inputs and the RNG stream.
     fn next_state(
         &self,
         time_index: usize,

--- a/src/product/definition.rs
+++ b/src/product/definition.rs
@@ -1,0 +1,92 @@
+use crate::rng::RngCore;
+
+use super::{Amount, ProductState, RequiredDataBuffer, RequiredDataLayout};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProductDefinitionError;
+
+/// Fixed definition of a product's dimensions and required data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProductDefinition {
+    pub n_states: usize,
+    pub n_kinds: usize,
+    pub required_data: RequiredDataLayout,
+}
+
+impl ProductDefinition {
+    pub fn new(
+        n_states: usize,
+        n_kinds: usize,
+        required_data: RequiredDataLayout,
+    ) -> Result<Self, ProductDefinitionError> {
+        if n_states == 0 || n_kinds == 0 {
+            return Err(ProductDefinitionError);
+        }
+        Ok(Self {
+            n_states,
+            n_kinds,
+            required_data,
+        })
+    }
+}
+
+/// Product interface describing cashflow kinds, states, and required data.
+pub trait Product {
+    /// Returns the fixed definition of the product's dimensions.
+    fn definition(&self) -> &ProductDefinition;
+
+    /// Provides the initial state for the projection.
+    fn initial_state(&self) -> ProductState;
+
+    /// Generates required data into the provided buffer.
+    fn generate_required_data(
+        &self,
+        time_index: usize,
+        state: &ProductState,
+        rng: &mut dyn RngCore,
+        out: &mut RequiredDataBuffer,
+    );
+
+    /// Writes cashflows for the current state into the provided buffer.
+    ///
+    /// The output slice length must match `definition().n_kinds`.
+    fn cashflows(
+        &self,
+        time_index: usize,
+        state: &ProductState,
+        data: &RequiredDataBuffer,
+        out: &mut [Amount],
+    );
+
+    /// Computes the next state after applying transitions.
+    fn next_state(
+        &self,
+        time_index: usize,
+        state: &ProductState,
+        data: &RequiredDataBuffer,
+        rng: &mut dyn RngCore,
+    ) -> ProductState;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::product::RequiredDataLayoutError;
+
+    #[test]
+    fn product_definition_rejects_invalid_shapes() {
+        let layout = RequiredDataLayout::new(1, 1).unwrap();
+        assert!(ProductDefinition::new(0, 1, layout).is_err());
+        assert!(ProductDefinition::new(1, 0, layout).is_err());
+    }
+
+    #[test]
+    fn product_definition_accepts_valid_shapes() -> Result<(), RequiredDataLayoutError> {
+        let layout = RequiredDataLayout::new(1, 2)?;
+        let def = ProductDefinition::new(2, 3, layout).unwrap();
+        assert_eq!(def.n_states, 2);
+        assert_eq!(def.n_kinds, 3);
+        assert_eq!(def.required_data, layout);
+        Ok(())
+    }
+}

--- a/src/product/mod.rs
+++ b/src/product/mod.rs
@@ -1,7 +1,11 @@
 pub mod cashflow;
+pub mod definition;
+pub mod required;
 pub mod state;
 
-pub use cashflow::{Amount, Cashflow, CashflowKind};
+pub use cashflow::{Amount, Cashflow, CashflowBuffer, CashflowKindId};
+pub use definition::{Product, ProductDefinition};
+pub use required::{RequiredDataBuffer, RequiredDataLayout, RequiredDataLayoutError};
 pub use state::ProductState;
 
 #[cfg(test)]
@@ -11,23 +15,22 @@ mod tests {
 
     #[test]
     fn cashflow_new_sets_fields() -> Result<(), DateError> {
-        let amount = Amount::from_cents(12_50);
+        let amount = Amount::from_f64(12.5);
         let date = Date::new(2024, 5, 15)?;
-        let cf = Cashflow::new(date, amount, CashflowKind::Premium);
+        let cf = Cashflow::new(date, amount, CashflowKindId(0));
 
         assert_eq!(cf.time, date);
         assert_eq!(cf.amount, amount);
-        assert_eq!(cf.kind, CashflowKind::Premium);
+        assert_eq!(cf.kind, CashflowKindId(0));
         Ok(())
     }
 
     #[test]
     fn cashflow_from_period_uses_date_utilities() -> Result<(), DateError> {
-        let amount = Amount::from_cents(25_00);
+        let amount = Amount::from_f64(25.0);
         let start = Date::new(2023, 1, 31)?;
 
-        let cf =
-            Cashflow::from_period(start, 1, Frequency::Monthly, amount, CashflowKind::Benefit)?;
+        let cf = Cashflow::from_period(start, 1, Frequency::Monthly, amount, CashflowKindId(2))?;
 
         assert_eq!(cf.time, Date::new(2023, 2, 28)?);
         Ok(())
@@ -36,11 +39,11 @@ mod tests {
     #[test]
     fn cashflows_can_be_ordered_by_date() -> Result<(), DateError> {
         let start = Date::new(2023, 1, 1)?;
-        let amount = Amount::from_cents(10_00);
+        let amount = Amount::from_f64(10.0);
         let mut flows = [
-            Cashflow::from_period(start, 2, Frequency::Weekly, amount, CashflowKind::Other)?,
-            Cashflow::from_period(start, 0, Frequency::Weekly, amount, CashflowKind::Other)?,
-            Cashflow::from_period(start, 1, Frequency::Weekly, amount, CashflowKind::Other)?,
+            Cashflow::from_period(start, 2, Frequency::Weekly, amount, CashflowKindId(1))?,
+            Cashflow::from_period(start, 0, Frequency::Weekly, amount, CashflowKindId(1))?,
+            Cashflow::from_period(start, 1, Frequency::Weekly, amount, CashflowKindId(1))?,
         ];
 
         flows.sort_by_key(|flow| flow.time);
@@ -53,10 +56,10 @@ mod tests {
 
     #[test]
     fn reserve_change_updates_reserves_only() {
-        let mut state = ProductState::new(75, Amount::from_cents(80_00));
+        let mut state = ProductState::new(1, 75, Amount::from_f64(80.0));
 
-        state.apply_reserve_change(Amount::from_cents(-5_00));
+        state.apply_reserve_change(Amount::from_f64(-5.0));
 
-        assert_eq!(state.reserves, Amount::from_cents(75_00));
+        assert_eq!(state.reserves, Amount::from_f64(75.0));
     }
 }

--- a/src/product/required.rs
+++ b/src/product/required.rs
@@ -1,0 +1,144 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RequiredDataLayoutError;
+
+/// Fixed required data dimensions for a product.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RequiredDataLayout {
+    policy_scalars: usize,
+    state_vectors: usize,
+}
+
+impl RequiredDataLayout {
+    pub fn new(
+        policy_scalars: usize,
+        state_vectors: usize,
+    ) -> Result<Self, RequiredDataLayoutError> {
+        if policy_scalars == 0 && state_vectors == 0 {
+            return Err(RequiredDataLayoutError);
+        }
+        Ok(Self {
+            policy_scalars,
+            state_vectors,
+        })
+    }
+
+    pub const fn policy_scalars(&self) -> usize {
+        self.policy_scalars
+    }
+
+    pub const fn state_vectors(&self) -> usize {
+        self.state_vectors
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RequiredDataBufferError;
+
+/// SoA required data storage: per-policy scalars and per-state vectors.
+#[derive(Debug, Clone)]
+pub struct RequiredDataBuffer {
+    layout: RequiredDataLayout,
+    n_states: usize,
+    policy_scalars: Vec<f64>,
+    state_vectors: Vec<f64>,
+}
+
+impl RequiredDataBuffer {
+    pub fn new(
+        layout: RequiredDataLayout,
+        n_states: usize,
+    ) -> Result<Self, RequiredDataBufferError> {
+        if n_states == 0 {
+            return Err(RequiredDataBufferError);
+        }
+        let scalars = vec![0.0; layout.policy_scalars()];
+        let vectors_len = layout
+            .state_vectors()
+            .checked_mul(n_states)
+            .ok_or(RequiredDataBufferError)?;
+        let vectors = vec![0.0; vectors_len];
+        Ok(Self {
+            layout,
+            n_states,
+            policy_scalars: scalars,
+            state_vectors: vectors,
+        })
+    }
+
+    pub fn from_parts(
+        layout: RequiredDataLayout,
+        n_states: usize,
+        policy_scalars: Vec<f64>,
+        state_vectors: Vec<f64>,
+    ) -> Result<Self, RequiredDataBufferError> {
+        if n_states == 0 {
+            return Err(RequiredDataBufferError);
+        }
+        if policy_scalars.len() != layout.policy_scalars() {
+            return Err(RequiredDataBufferError);
+        }
+        let expected = layout
+            .state_vectors()
+            .checked_mul(n_states)
+            .ok_or(RequiredDataBufferError)?;
+        if state_vectors.len() != expected {
+            return Err(RequiredDataBufferError);
+        }
+        Ok(Self {
+            layout,
+            n_states,
+            policy_scalars,
+            state_vectors,
+        })
+    }
+
+    pub const fn layout(&self) -> RequiredDataLayout {
+        self.layout
+    }
+
+    pub const fn n_states(&self) -> usize {
+        self.n_states
+    }
+
+    pub fn policy_scalar(&self, index: usize) -> f64 {
+        debug_assert!(index < self.policy_scalars.len());
+        self.policy_scalars[index]
+    }
+
+    pub fn set_policy_scalar(&mut self, index: usize, value: f64) {
+        debug_assert!(index < self.policy_scalars.len());
+        self.policy_scalars[index] = value;
+    }
+
+    pub fn state_vector(&self, field: usize) -> &[f64] {
+        let start = self.state_vector_offset(field);
+        &self.state_vectors[start..start + self.n_states]
+    }
+
+    pub fn state_vector_mut(&mut self, field: usize) -> &mut [f64] {
+        let start = self.state_vector_offset(field);
+        &mut self.state_vectors[start..start + self.n_states]
+    }
+
+    fn state_vector_offset(&self, field: usize) -> usize {
+        debug_assert!(field < self.layout.state_vectors());
+        field * self.n_states
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn required_data_buffer_indexes_match_layout() {
+        let layout = RequiredDataLayout::new(2, 3).unwrap();
+        let mut data = RequiredDataBuffer::new(layout, 4).unwrap();
+        data.set_policy_scalar(1, 12.5);
+        assert_eq!(data.policy_scalar(1), 12.5);
+
+        data.state_vector_mut(2)[3] = -7.0;
+        assert_eq!(data.state_vector(2)[3], -7.0);
+        assert_eq!(data.state_vector(0).len(), 4);
+    }
+}

--- a/src/product/state.rs
+++ b/src/product/state.rs
@@ -1,14 +1,19 @@
 use super::Amount;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ProductState {
+    pub state_id: usize,
     pub in_force: u64,
     pub reserves: Amount,
 }
 
 impl ProductState {
-    pub const fn new(in_force: u64, reserves: Amount) -> Self {
-        Self { in_force, reserves }
+    pub const fn new(state_id: usize, in_force: u64, reserves: Amount) -> Self {
+        Self {
+            state_id,
+            in_force,
+            reserves,
+        }
     }
 
     pub fn apply_reserve_change(&mut self, delta: Amount) {

--- a/src/rng/mod.rs
+++ b/src/rng/mod.rs
@@ -17,6 +17,9 @@ pub trait BlockSplit: Sized {
 }
 
 /// Core 32-bit RNG interface.
+///
+/// Determinism: given the same internal state, implementations must return the
+/// same sequence of values.
 pub trait RngCore {
     fn next_u32(&mut self) -> u32;
 

--- a/src/rng/mod.rs
+++ b/src/rng/mod.rs
@@ -1,6 +1,22 @@
 pub mod mgk32a;
 pub mod sobol;
 
+/// Deterministic jump-ahead for reproducible streams.
+pub trait JumpAhead {
+    type Error;
+
+    fn advance(&mut self, delta: u128) -> Result<(), Self::Error>;
+}
+
+/// Block splitting via jump-ahead for parallel stream construction.
+pub trait BlockSplit: Sized {
+    type Seed;
+    type Error;
+
+    fn for_stream(seed: Self::Seed, stream: u128, stride: u128) -> Result<Self, Self::Error>;
+}
+
+/// Core 32-bit RNG interface.
 pub trait RngCore {
     fn next_u32(&mut self) -> u32;
 


### PR DESCRIPTION
## Summary
- define product traits and required data SoA buffers
- add model interface and buffer validation
- extend RNG interfaces with jump-ahead and block-splitting; add determinism tests
- add model/product contract tests plus Model rustdoc example doctest
- update cashflow layout and Amount newtype to f64
- document core modules in README

## Acceptance Criteria Mapping
- Product/RNG/Model trait definitions and docs: `src/product/definition.rs`, `src/rng/mod.rs`, `src/model/mod.rs`
- RNG determinism, jump-ahead, block-splitting tests: `src/rng/mgk32a.rs`, `src/rng/sobol.rs`
- Model uses product-defined required data shape (contract tests): `src/model/mod.rs`
- Doc example coverage for API usage: `src/model/mod.rs`

## Commands
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo doc`
- `cargo bench`
- `cargo llvm-cov` (failed: missing `llvm-tools-preview`; install or set `LLVM_COV`/`LLVM_PROFDATA`)

## Notes
- SENTINEL reviewed the diff; approval pending.
- No new dependencies.

Closes #33
